### PR TITLE
we do not need SEO metadata fields for i18n pieces

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
   name: 'apostrophe-i18n-static',
   label: 'I18n static piece',
   pluralLabel: 'I18n static pieces',
+  seo: false,
   moogBundle: {
     modules: ['apostrophe-i18n-templates'],
     directory: 'lib/modules'


### PR DESCRIPTION
There was code to do this via improve in apostrophe-seo but since apostrophe-i18n-static might or might not be present in a project that is not a good idea. Easier and correct fix is to just set the seo: false option in apostrophe-i18n-static. While attempting to improve a nonexistent module is a fatal error, setting an option that no code looks at (in a project that lacks  apostrophe-seo) is harmless.