### PR TITLE
Fix possible duplication bug if `objectNotation` is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.1 - 09-30-2020
+
+Fixed possible duplication bug if `objectNotation` is true.
+
 ## 1.1.0 - 07-29-2020
 
 Added option "verbose".

--- a/lib/modules/apostrophe-i18n-templates/index.js
+++ b/lib/modules/apostrophe-i18n-templates/index.js
@@ -47,7 +47,10 @@ module.exports = {
             //       "obj": "deep nested value"
             //    }
             // }
-            const objectNotation = self.apos.modules['apostrophe-i18n-static'].options.objectNotation;
+            let objectNotation = self.apos.modules['apostrophe-i18n-static'].options.objectNotation;
+            if (objectNotation === true) { // important: only when boolean "true"
+              objectNotation = '.';
+            }
             const keys = key.split(objectNotation);
 
             const existingNestedKey = findNestedKey(content, keys);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-i18n-static",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Translation editable pieces with I18n",
   "main": "index.js",
   "author": "@apostrophecms",


### PR DESCRIPTION
Problem when `objectNotation` is `true`, it was not transformed as `.` (default value) and nested obejcts were duplicated.