### PR TITLE
push and pop req.locale and req.res.locale during self.apos.templates…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
+## 1.2.1 - 01-27-2021
 
-## 1.2.0 - 01-27-2021
+* Solves an issue where only default locale strings were obtained by `req.__()` when editing in draft mode with the workflow module. Since this module does not write `-draft` locale JSON files, make sure `apos.templates.i18n` sees only the base locale name, but take care to restore `req.locale` and `req.res.locale` afterwards to avoid any issues for the workflow module.
+
+## 1.2.0 - 01-25-2021
 
 * Collection used rather than cache to avoid issues when the database is shared between environments but the cache is not.
 

--- a/lib/modules/apostrophe-i18n-templates/index.js
+++ b/lib/modules/apostrophe-i18n-templates/index.js
@@ -49,7 +49,16 @@ module.exports = {
       if (key) {
         insertMissing();
       }
-      return superI18n.apply(null, Array.prototype.slice.call(arguments));
+
+      // Push and pop the true workflow locale so that the proper string
+      // is found in the JSON files (this module does not create -draft files)
+      const trueLocale = req.locale;
+      req.locale = self.apos.modules['apostrophe-i18n-static'].getLocale(req);
+      req.res.locale = req.locale;
+      const result = superI18n.apply(null, Array.prototype.slice.call(arguments));
+      req.locale = trueLocale;
+      req.res.locale = trueLocale;
+      return result;
 
       function findNestedKey(content, keys) {
         const key = keys.shift();
@@ -65,7 +74,6 @@ module.exports = {
         insertMissingCount++;
         try {
           const locale = self.apos.modules['apostrophe-i18n-static'].getLocale(req);
-          req.res.locale = locale; // for apostrophe-workflow: override locale in order to use translations from the currently displayed workflow locale
           let content = i18nContents[locale];
           if (!content) {
             i18nContents[locale] = await self.apos.modules['apostrophe-i18n-static'].find(req, {


### PR DESCRIPTION
….i18n, so they have their proper workflow-aware values at all other times