### PR TITLE
Wrap req.locale earlier, in middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.2.2 - 01-27-2021
+
+* Further corrections to phrase lookup in draft mode, to address the issue earlier in middleware.
+
 ## 1.2.1 - 01-27-2021
 
 * Solves an issue where only default locale strings were obtained by `req.__()` when editing in draft mode with the workflow module. Since this module does not write `-draft` locale JSON files, make sure `apos.templates.i18n` sees only the base locale name, but take care to restore `req.locale` and `req.res.locale` afterwards to avoid any issues for the workflow module.

--- a/lib/modules/apostrophe-i18n-templates/index.js
+++ b/lib/modules/apostrophe-i18n-templates/index.js
@@ -50,15 +50,7 @@ module.exports = {
         insertMissing();
       }
 
-      // Push and pop the true workflow locale so that the proper string
-      // is found in the JSON files (this module does not create -draft files)
-      const trueLocale = req.locale;
-      req.locale = self.apos.modules['apostrophe-i18n-static'].getLocale(req);
-      req.res.locale = req.locale;
-      const result = superI18n.apply(null, Array.prototype.slice.call(arguments));
-      req.locale = trueLocale;
-      req.res.locale = trueLocale;
-      return result;
+      return superI18n.apply(null, Array.prototype.slice.call(arguments));
 
       function findNestedKey(content, keys) {
         const key = keys.shift();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-i18n-static",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Translation editable pieces with I18n",
   "main": "index.js",
   "author": "@apostrophecms",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-i18n-static",
-  "version": "1.2.2",
+  "version": "1.2.2-beta.1",
   "description": "Translation editable pieces with I18n",
   "main": "index.js",
   "author": "@apostrophecms",


### PR DESCRIPTION
Turns out, the apos.templates.i18n method is not currently used for calls to `req.__` and `res.__`. There is a separate mechanism. This is basically because all of our namespacing support is a hack on top of the `i18n` npm module which was never intended for it.

So since applying the super pattern to that method is not enough to cover all cases, I moved the super pattern to the middleware.  This resolves the issue in a satisfactory manner per DCAD.